### PR TITLE
Make more errors retryable

### DIFF
--- a/lib/rpush/daemon/apnsp8/delivery.rb
+++ b/lib/rpush/daemon/apnsp8/delivery.rb
@@ -29,7 +29,7 @@ module Rpush
           mark_batch_retryable(Time.now + 10.seconds, error)
           @client.close
           raise
-        rescue Errno::ECONNREFUSED, SocketError, HTTP2::Error::StreamLimitExceeded => error
+        rescue Errno::EHOSTUNREACH, Errno::ETIMEDOUT, Errno::ECONNRESET, Errno::ECONNREFUSED, SocketError, HTTP2::Error::StreamLimitExceeded => error
           # TODO restart connection when StreamLimitExceeded
           mark_batch_retryable(Time.now + 10.seconds, error)
           raise

--- a/lib/rpush/daemon/gcm/delivery.rb
+++ b/lib/rpush/daemon/gcm/delivery.rb
@@ -19,7 +19,7 @@ module Rpush
 
         def perform
           handle_response(do_post)
-        rescue SocketError => error
+        rescue Errno::EHOSTUNREACH, Errno::ECONNRESET, SocketError => error
           mark_retryable(@notification, Time.now + 10.seconds, error)
           raise
         rescue StandardError => error


### PR DESCRIPTION
With the usage that has been given to Rpush, it was found a couple of errors that happen frequently enough that deserve to be retried instead of just marking the notifications as failed.