### PR TITLE
Establish connection to the right database

### DIFF
--- a/lib/rpush/daemon/store/active_record/reconnectable.rb
+++ b/lib/rpush/daemon/store/active_record/reconnectable.rb
@@ -62,7 +62,9 @@ module Rpush
 
           def reconnect_database
             ::Rpush::Client::ActiveRecord::Base.clear_all_connections!
-            ::Rpush::Client::ActiveRecord::Base.establish_connection
+            ::Rpush::Client::ActiveRecord::Base.establish_connection(
+              ::Rpush::Client::ActiveRecord::Base.connection_db_config.name.to_sym
+            )
           end
 
           def check_database_is_connected


### PR DESCRIPTION
Ensure that on establishing back the database connection, it uses the right configuration.

This can be seen by doing the following in a rails console:

```
::Rpush::Client::ActiveRecord::Base.connection_db_config.name.to_sym == :rpush #=> true
::Rpush::Client::ActiveRecord::Base.establish_connection(::Rpush::Client::ActiveRecord::Base.connection_db_config.name.to_sym);
::Rpush::Client::ActiveRecord::Base.connection_db_config.name.to_sym == :rpush #=> true
::Rpush::Client::ActiveRecord::Base.establish_connection;
::Rpush::Client::ActiveRecord::Base.connection_db_config.name.to_sym == :primary #=> true
```