### PR TITLE
make data pushes work

### DIFF
--- a/lib/rpush/client/active_model/fcm/notification.rb
+++ b/lib/rpush/client/active_model/fcm/notification.rb
@@ -66,9 +66,8 @@ module Rpush
           end
 
           def android_config
-            json = {
-              'notification' => android_notification,
-            }
+            json = {}
+            json['notification'] = android_notification if notification
             json['collapse_key'] = collapse_key if collapse_key
             json['priority'] = priority_str if priority
             json['ttl'] = "#{expiry}s" if expiry
@@ -89,7 +88,7 @@ module Rpush
             json = notification&.slice(*ANDROID_NOTIFICATION_KEYS) || {}
             json['notification_priority'] = priority_for_notification if priority
             json['sound'] = sound if sound
-            json['default_sound'] = !sound || sound == 'default' ? true : false
+            json['default_sound'] = (!sound || sound == 'default' ? true : false) if notification
             json
           end
 


### PR DESCRIPTION
Rpush is currently adding this bit to every notification:
```json
  "android": {
    "notification": {
      "notification_priority":"PRIORITY_MAX",
      "default_sound":true
     },
```
The `notification` field breaks data pushes, i.e. pushes that should be only handled by our app and ignored by FCM SDK. We only used pushes like those and I thought that they became impossible in the new API, but it was that little bit that broke them. I think that after tweaking our implementation everything will work again as it worked before. We'll be able to bring back the silent pushes as well.